### PR TITLE
Ignore {{}} syntax in template/CITATION.cff Linting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore {{}} syntax in CITATION.cff
+template/CITATION.cff


### PR DESCRIPTION
Fixes failing lint CI in #28

Ref: #23