### PR TITLE
fix: Format asking for repository name with username

### DIFF
--- a/dist/setup.js
+++ b/dist/setup.js
@@ -36,7 +36,7 @@ const fetchInfo = async (cleanup) => {
         },
     ]);
     const username = await question('Username? (https://github.com/<username>)\n=> ');
-    const repository = await question('Repository? ((https://github.com/$username/<repo>\n=> ');
+    const repository = await question(`Repository? (https://github.com/${username}/<repo>)\n=> `);
     const proj_name = await question('Project name?\n=> ');
     const proj_short_desc = await question('Short description?\n=> ');
     const proj_long_desc = await question('Long description?\n=> ');

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -52,7 +52,7 @@ const fetchInfo = async (
     'Username? (https://github.com/<username>)\n=> ',
   );
   const repository = await question(
-    'Repository? ((https://github.com/$username/<repo>\n=> ',
+    `Repository? (https://github.com/${username}/<repo>)\n=> `,
   );
   const proj_name = await question('Project name?\n=> ');
   const proj_short_desc = await question('Short description?\n=> ');


### PR DESCRIPTION
This patch fixes the string for asking for the repository name by actually formatting the previously passed "username" into "$username" and making the parenthesis wrap the url.