### PR TITLE
fix: Rm with -f for development-only files and dirs

### DIFF
--- a/dist/setup.js
+++ b/dist/setup.js
@@ -122,6 +122,9 @@ const { func: main } = (0, io_util_1.withTempDir)('caffeine-addictt-template-', 
     // ################# //
     // Stage 3: Clean up //
     // ################# //
+    // Only add `force: true` for files or directories that
+    // will only exist if some development task was carried out
+    // like eslintcache
     console.log('Cleaning up...');
     // Js
     fs_1.default.unlinkSync('package.json');
@@ -133,16 +136,16 @@ const { func: main } = (0, io_util_1.withTempDir)('caffeine-addictt-template-', 
     fs_1.default.unlinkSync('babel.config.cjs');
     fs_1.default.rmSync('tests', { recursive: true });
     // Linting
-    fs_1.default.unlinkSync('.eslintcache');
     fs_1.default.unlinkSync('.eslintignore');
     fs_1.default.unlinkSync('.prettierignore');
     fs_1.default.unlinkSync('eslint.config.mjs');
+    fs_1.default.rmSync('.eslintcache', { force: true });
     // Syncing
     fs_1.default.unlinkSync('.templatesyncignore');
     // Git
     fs_1.default.unlinkSync('.gitignore');
     // Node
-    fs_1.default.rmSync('node_modules', { recursive: true });
+    fs_1.default.rmSync('node_modules', { recursive: true, force: true });
     // Clean up dist
     fs_1.default.unlinkSync(__filename);
     fs_1.default.rmSync('dist', { recursive: true });

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -167,6 +167,9 @@ const { func: main } = withTempDir(
     // ################# //
     // Stage 3: Clean up //
     // ################# //
+    // Only add `force: true` for files or directories that
+    // will only exist if some development task was carried out
+    // like eslintcache
     console.log('Cleaning up...');
 
     // Js
@@ -182,10 +185,10 @@ const { func: main } = withTempDir(
     fs.rmSync('tests', { recursive: true });
 
     // Linting
-    fs.unlinkSync('.eslintcache');
     fs.unlinkSync('.eslintignore');
     fs.unlinkSync('.prettierignore');
     fs.unlinkSync('eslint.config.mjs');
+    fs.rmSync('.eslintcache', { force: true });
 
     // Syncing
     fs.unlinkSync('.templatesyncignore');
@@ -194,7 +197,7 @@ const { func: main } = withTempDir(
     fs.unlinkSync('.gitignore');
 
     // Node
-    fs.rmSync('node_modules', { recursive: true });
+    fs.rmSync('node_modules', { recursive: true, force: true });
 
     // Clean up dist
     fs.unlinkSync(__filename);


### PR DESCRIPTION
This patch fixes #58 by force deleting files and directories that would only exist if development was carried out. Adding -f or force will suppress any "not found" errors. Examples of development-only include `node_modules/` and `.eslintcache`.

Closes #58
Ref: #58